### PR TITLE
Set TARGET_PROVIDES_QTI_TELEPHONY_JAR

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -199,6 +199,9 @@ USE_DEVICE_SPECIFIC_THERMAL := true
 # Use Snapdragon LLVM, if available
 TARGET_USE_SDCLANG := true
 
+# Telephony
+TARGET_PROVIDES_QTI_TELEPHONY_JAR := true
+
 # Wi-Fi
 WPA_SUPPLICANT_VERSION      := VER_0_8_X
 BOARD_WLAN_DEVICE           := bcmdhd


### PR DESCRIPTION
Fixes error: vendor/lge/msm8996-common: MODULE.TARGET.JAVA_LIBRARIES.qti-telephony-common already defined