### PR TITLE
Update SELinux policy for fingerprint error log

### DIFF
--- a/sepolicy/hal_fingerprint_default.te
+++ b/sepolicy/hal_fingerprint_default.te
@@ -13,3 +13,4 @@ allow hal_fingerprint_default sysfs:file write;
 allow hal_fingerprint_default fingerprintd_data_file:dir { write search add_name remove_name };
 allow hal_fingerprint_default fingerprintd_data_file:file { open getattr unlink rename };
 allow hal_fingerprint_default system_data_file:dir { add_name write create };
+allow hal_fingerprint_default system_data_file:file write;


### PR DESCRIPTION
Hi,

I have some issues with my fingerprint reader on h870 ("unavailable hardware device"). I found out it was trying to log errors in the  `/data/fpc/error_log` file but was denied from doing so due to SELinux policy. Denial was:

```
avc: denied { write } for name="error_log" dev="sda17" ino=1240325 scontext=u:r:hal_fingerprint_default:s0 tcontext=u:object_r:system_data_file:s0 tclass=file permissive=0
```

This PR should let it write this error log (not solving the underlying issue though).

Best,